### PR TITLE
Convert value before showing in popup if it doesn't fit in multibutton

### DIFF
--- a/uppsrc/CtrlLib/MultiButton.cpp
+++ b/uppsrc/CtrlLib/MultiButton.cpp
@@ -611,7 +611,7 @@ void MultiButton::SyncInfo()
 			int cm = DPI(2);
 			r.left -= cm;
 			r.right += cm;
-			info.Set(this, r, value, display, SColorText, style->paper, 0, DPI(2));
+			info.Set(this, r, v, display, SColorText, style->paper, 0, DPI(2));
 			return;
 		}
 	}


### PR DESCRIPTION
The SyncInfo() of a MultiButton uses the unconverted value to show in the display. This change makes sure the value is converted first (as probably was the intention as a convert->Format() was included, but the converted value was never used).